### PR TITLE
Allow use of base class SimpleUser\User as well as child classes

### DIFF
--- a/src/SimpleUser/UserManager.php
+++ b/src/SimpleUser/UserManager.php
@@ -84,7 +84,7 @@ class UserManager implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return is_subclass_of($class, 'SimpleUser\User');
+        return ($class === 'SimpleUser\User') || is_subclass_of($class, 'SimpleUser\User');
     }
 
     // ----- End UserProviderInterface -----

--- a/tests/SimpleUser/Tests/UserManagerTest.php
+++ b/tests/SimpleUser/Tests/UserManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleUser\Tests;
 
+use SimpleUser\User;
 use SimpleUser\UserManager;
 use Silex\Application;
 use Silex\Provider\DoctrineServiceProvider;
@@ -187,4 +188,38 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($errors);
     }
 
+
+    public function testSupportsBaseClass()
+    {
+        $user = $this->userManager->createUser('test@example.com', 'password');
+
+        $supportsObject = $this->userManager->supportsClass(get_class($user));
+        $this->assertTrue($supportsObject);
+
+        $this->userManager->insert($user);
+        $freshUser = $this->userManager->refreshUser($user);
+
+        $supportsRefreshedObject = $this->userManager->supportsClass(get_class($freshUser));
+        $this->assertTrue($supportsRefreshedObject);
+
+        $this->assertTrue($freshUser instanceof User);
+    }
+
+    public function testSupportsSubClass()
+    {
+        $this->userManager->setUserClass('\SimpleUser\Tests\CustomUser');
+
+        $user = $this->userManager->createUser('test@example.com', 'password');
+
+        $supportsObject = $this->userManager->supportsClass(get_class($user));
+        $this->assertTrue($supportsObject);
+
+        $this->userManager->insert($user);
+        $freshUser = $this->userManager->refreshUser($user);
+
+        $supportsRefreshedObject = $this->userManager->supportsClass(get_class($freshUser));
+        $this->assertTrue($supportsRefreshedObject);
+
+        $this->assertTrue($freshUser instanceof CustomUser);
+    }
 }


### PR DESCRIPTION
Add tests to ensure that UserManages supports and can refresh both.

Fix for https://github.com/jasongrimes/silex-simpleuser/issues/8
