### PR TITLE
Implemented changeable column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,25 @@ The default values are shown below.
         // Override table names, if necessary.
         'userTableName' => 'users',
         'userCustomFieldsTableName' => 'user_custom_fields',
+
+        //Override Column names, if necessary
+        'userColumns' = array(
+            'id' => 'id',
+            'email' => 'email',
+            'password' => 'password',
+            'salt' => 'salt',
+            'roles' => 'roles',
+            'name' => 'name',
+            'time_created' => 'time_created',
+            'username' => 'username',
+            'isEnabled' => 'isEnabled',
+            'confirmationToken' => 'confirmationToken',
+            'timePasswordResetRequested' => 'timePasswordResetRequested',
+            //Custom Fields
+            'user_id' => 'user_id',
+            'attribute' => 'attribute',
+            'value' => 'value',
+        ),
     );
 
 More information

--- a/src/SimpleUser/UserServiceProvider.php
+++ b/src/SimpleUser/UserServiceProvider.php
@@ -73,6 +73,25 @@ class UserServiceProvider implements ServiceProviderInterface, ControllerProvide
             // Override table names, if necessary.
             'userTableName' => 'users',
             'userCustomFieldsTableName' => 'user_custom_fields',
+
+            // Override column names if necessary.
+            'userColumns' => array(
+                'id' => 'id',
+                'email' => 'email',
+                'password' => 'password',
+                'salt' => 'salt',
+                'roles' => 'roles',
+                'name' => 'name',
+                'time_created' => 'time_created',
+                'username' => 'username',
+                'isEnabled' => 'isEnabled',
+                'confirmationToken' => 'confirmationToken',
+                'timePasswordResetRequested' => 'timePasswordResetRequested',
+                //Custom Fields
+                'user_id' => 'user_id',
+                'attribute' => 'attribute',
+                'value' => 'value',
+            ),
         );
 
         // Initialize $app['user.options'].
@@ -117,6 +136,7 @@ class UserServiceProvider implements ServiceProviderInterface, ControllerProvide
             $userManager->setUsernameRequired($app['user.options']['isUsernameRequired']);
             $userManager->setUserTableName($app['user.options']['userTableName']);
             $userManager->setUserCustomFieldsTableName($app['user.options']['userCustomFieldsTableName']);
+            $userManager->setUserColumns($app['user.options']['userColumns']);
 
             return $userManager;
         });

--- a/tests/SimpleUser/Tests/UserManagerTest.php
+++ b/tests/SimpleUser/Tests/UserManagerTest.php
@@ -409,4 +409,10 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $error = $this->userManager->validatePasswordStrength($user, 'a');
         $this->assertEquals('Password must have at least 2 characters.', $error);
     }
+
+    public function testChangeUserColumns()
+    {
+        $this->userManager->setUserColumns(array('email' => 'foo'));
+        $this->assertEquals('"foo"', $this->userManager->getUserColumns('email'));
+    }
 }

--- a/tests/SimpleUser/Tests/UserServiceProviderTest.php
+++ b/tests/SimpleUser/Tests/UserServiceProviderTest.php
@@ -16,7 +16,12 @@ class UserServiceProviderTest extends \PHPUnit_Framework_TestCase
             array('security.firewalls' => array('dummy-firewall' => array('form' => array())))
         );
         $app->register(new Provider\DoctrineServiceProvider());
-        $app->register(new UserServiceProvider());
+        $app->register(new UserServiceProvider(), array(
+            'db.options' => array(
+                'driver' => 'pdo_sqlite',
+                'memory' => true,
+            ),
+        ));
 
         return $app;
     }


### PR DESCRIPTION
This is in regards to Issue #37.

 - Wrote `getUserColumns()` and `setUserColumns()`.
 - Updated all of the queries and internal $criteria definitions to use `getUserColumns($column)`.
 - Wrote `testChangeUserColumns()` in UserManager.
 - Changed `UserServiceProvider` initialisation during testing to include an in-memory sqlite DB so that `$conn->quoteIdentifier()` doesn't fail.