### PR TITLE
Fixes for Custom Column Names

### DIFF
--- a/tests/SimpleUser/Tests/UserManagerTest.php
+++ b/tests/SimpleUser/Tests/UserManagerTest.php
@@ -413,6 +413,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
     public function testChangeUserColumns()
     {
         $this->userManager->setUserColumns(array('email' => 'foo'));
-        $this->assertEquals('"foo"', $this->userManager->getUserColumns('email'));
+        $this->assertEquals('foo', $this->userManager->getUserColumns('email'));
+        $this->assertEquals('"foo"',$this->userManager->getUserColumns('email',true));
     }
 }


### PR DESCRIPTION
The unit tests didn't cover everything, so when trying to use this there were some errors with the escaping occurring for the query parameter identifiers too.
I have fixed this with some restructuring of the functions.
