### PR TITLE
Editing should assert {id} is a digit

### DIFF
--- a/src/SimpleUser/UserServiceProvider.php
+++ b/src/SimpleUser/UserServiceProvider.php
@@ -290,7 +290,8 @@ class UserServiceProvider implements ServiceProviderInterface, ControllerProvide
                 if (!$app['security']->isGranted('EDIT_USER_ID', $request->get('id'))) {
                     throw new AccessDeniedException();
                 }
-            });
+            })
+            ->assert('id', '\d+');
 
         $controllers->get('/list', 'user.controller:listAction')
             ->bind('user.list');


### PR DESCRIPTION
Just fixing an inconsistency.  Since id is only a digit in the view route it should be asserted in the 'edit' route.
